### PR TITLE
Genre Pages and usage of the random buttons 

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -5,7 +5,7 @@ require_relative "helper.rb"
 require_relative "scrapper.rb"
 
 DB = SQLite3::Database.new(File.join(File.dirname(__FILE__), 'db/jukebox.sqlite'))
-set :port, 4949
+set :port, 1111
 get "/" do
   @artists = display_all
   # TODO: Gather all artists to be displayed on home page
@@ -33,6 +33,12 @@ get "/tracks/:id" do
   # @test = @track[0][0].to_s
   # erb :test
   erb :track_page
+end
+
+get "/genres/:id" do
+  @artists_f_genre = all_from_genre(params[:id].to_i)
+
+  erb :genre_page
 end
 
 get "/random" do

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -49,6 +49,28 @@ def track_from_id(track_id)
   DB.execute(query)
 end
 
+def all_from_genre(genre_id)
+  query = <<-SQL
+    SELECT genres.name, artists.name, genres.id, artists.id
+    FROM artists
+    JOIN albums ON albums.artist_id = artists.id
+    JOIN tracks ON tracks.album_id = albums.id
+    JOIN genres ON tracks.genre_id = genres.id
+    WHERE genres.id = "#{genre_id}"
+    GROUP BY artists.name
+  SQL
+  DB.execute(query)
+end
+
+def get_genre_id(genre_name)
+  query = <<-SQL
+    SELECT genres.id
+    FROM genres
+    WHERE genres.name = "#{genre_name}"
+  SQL
+  DB.execute(query).join
+end
+
 def random_track_id(genre = nil)
   if genre
     query = <<-SQL

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -12,7 +12,7 @@ body {
   text-align: center;
 }
 h1 {
-  padding-top: 1em;
+  padding-top: 2em;
   font-size: 400%;
   font-family: Helvetica, sans-serif;
   color: #433e36;
@@ -31,6 +31,9 @@ a:hover {
   text-shadow: 1px 1px 5px #c5c2bd;
   color: #433e36;
   text-decoration: none;
+}
+span {
+  font-size: 150%;
 }
 .navbar-brand {
   color: #433e36;
@@ -62,6 +65,7 @@ a:hover {
 }
 #banner h1 {
   color: white;
+  padding-top: 1em;
 }
 #banner div {
   position: absolute;

--- a/lib/views/album_page.erb
+++ b/lib/views/album_page.erb
@@ -1,4 +1,4 @@
-<h2>Tracks</h2>
+<h1>Tracks</h1>
 <ul>
 <% @tracks.each do |track| %>
   <li><a href = "/tracks/ <%= track[1] %>" ><%= track[0] %> </li></a>

--- a/lib/views/genre_page.erb
+++ b/lib/views/genre_page.erb
@@ -1,0 +1,8 @@
+<h1><%= @artists_f_genre[0][0] %></h1>
+<h2>Artists</h2>
+<ul>
+  <li><span><a href="/tracks/<%= random_track_id(@artists_f_genre[0][0]) %>">Random <%= @artists_f_genre[0][0] %> Song!</a></span></li>
+<% @artists_f_genre.each do |artist| %>
+  <li><a href = "/artists/ <%= artist[3] %>" ><%= artist[1] %> </li></a>
+ <% end %>
+</ul>

--- a/lib/views/layout.erb
+++ b/lib/views/layout.erb
@@ -21,13 +21,13 @@
             <a class="nav-link" href="/">Home <span class="sr-only">(current)</span></a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#">Rock</a>
+            <a class="nav-link" href="/genres/ <%= get_genre_id('Rock') %>">Rock</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#">Classic</a>
+            <a class="nav-link" href="/genres/ <%= get_genre_id('Classical') %>">Classical</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#">Random Song</a>
+            <a class="nav-link" href="/tracks/<%= random_track_id %>">Random Song</a>
           </li>
         </ul>
         <form class="form-inline my-2 my-lg-0">


### PR DESCRIPTION
Add genres page that allows the user to use the navbar links and filter the artists by genre. Associate the random buttoms to links in the genres pages and the 'random song' link in the navbar. Changes the style of the tags h1 to fit better in the page. Change the tag h2 to h1 for 'tracks' in the albums page